### PR TITLE
Create a developer mode command to ease development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v1.1.0...master)
 
+* [#295](https://github.com/mozilla-rally/rally-core-addon/pull/295): Enable watching the repository and a better developer workflow using `npm run watch`.
+
 # v1.1.0 (2021-03-10)
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v1.0.0...v1.1.0)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,11 @@
     "test": "npm run --silent skip-taskcluster || (npm run test-addon && npm run test-support-library)",
     "test-addon": "npm run --silent skip-taskcluster || (mocha --unhandled-rejections=strict --require  \"./tests/hooks.js\" \"./tests/core-addon/unit/*.js\")",
     "test-integration": "npm run --silent skip-taskcluster || (npm run build && mocha --unhandled-rejections=strict --timeout 30000 \"./tests/core-addon/integration/*.js\")",
-    "test-support-library": "npm run --silent skip-taskcluster || (mocha --unhandled-rejections=strict --require  \"./tests/hooks.js\" \"./tests/support/*.mjs\")"
+    "test-support-library": "npm run --silent skip-taskcluster || (mocha --unhandled-rejections=strict --require  \"./tests/hooks.js\" \"./tests/support/*.mjs\")",
+    "watch": "npm-run-all --parallel watch-ui watch-addon watch-webext",
+    "watch-ui": "rollup -c -w",
+    "watch-addon": "rollup -c rollup.config.addon.js -w --config-disable-remote-settings --config-studies-list-url=/public/locally-available-studies.json",
+    "watch-webext": "web-ext run --watch-file public/build/build.js --watch-file public/addon-build/background.js --watch-file public/addon-build/content-script.js"
   },
   "devDependencies": {
     "@babel/core": "^7.13.10",


### PR DESCRIPTION
This introduces a 'watch' command. The command uses rollup to watch for UI and addon changes, updates the packed files, and makes sure web-ext picks up the changes. This fixes #3.

Unfortunately, if the rally control panel (addon options page) is open, that specific page does not get refreshed. User must refresh it manually or close/reopen that tab. That's due to a [bug in Firefox](https://bugzilla.mozilla.org/show_bug.cgi?id=1667143).

Checklist for reviewer:

- [x] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [x] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
