### PR TITLE
Fix tests and the config files

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,7 +18,7 @@ module.exports = {
     ChromeUtils: false,
     ExtensionAPI: false,
     // NOTE: These get injected via Rollup.
-    __ION_STUDIES_LIST__: false,
+    __STUDIES_LIST__: false,
     __ION_WEBSITE_URL__: false,
     __DISABLE_REMOTE_SETTINGS__: false,
     __DISABLE_LOCALE_CHECK__: false,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -19,10 +19,10 @@ module.exports = {
     ExtensionAPI: false,
     // NOTE: These get injected via Rollup.
     __STUDIES_LIST__: false,
-    __ION_WEBSITE_URL__: false,
     __DISABLE_REMOTE_SETTINGS__: false,
     __DISABLE_LOCALE_CHECK__: false,
     __ENABLE_DATA_SUBMISSION__: false,
+    __WEBSITE_URL__: false,
   },
   overrides: [
     {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased changes
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.8.0...master)
-  * [318](https://github.com/mozilla-rally/rally-core-addon/pull/311): Use Remote Settings for fetching study metadata.
-  * [328](https://github.com/mozilla-rally/rally-core-addon/pull/328): Update demographic survey to use "Latinx"; list answers for race question 4 alphabetically.
+
+* [#318](https://github.com/mozilla-rally/rally-core-addon/pull/311): Use Remote Settings for fetching study metadata.
+* [#328](https://github.com/mozilla-rally/rally-core-addon/pull/328): Update demographic survey to use "Latinx"; list answers for race question 4 alphabetically.
+* [#334](https://github.com/mozilla-rally/rally-core-addon/pull/334): Make Mocha stricter about unhandled exceptions in tests; fix the enable data submission option.
 
 # v0.8.0 (2021-02-01)
 

--- a/core-addon/Core.js
+++ b/core-addon/Core.js
@@ -8,25 +8,17 @@ const DataCollection = require("./DataCollection.js");
 // The path of the embedded resource used to control options.
 const OPTIONS_PAGE_PATH = "public/index.html";
 
-const DEFAULT_ARGS = {
-  // NOTE: if this URL ever changes, you will have to update the domain in
-  // the permissions in manifest.json.
-  availableStudiesURI: "https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/rally-studies-v1/records",
-  disableRemoteSettings: false,
-  website: "https://mozilla-rally.github.io",
-}
-
 module.exports = class Core {
   /**
    * @param {Object} args arguments passed in from the user.
    * @param {String} args.availableStudiesURI the URI where the available studies
    *             information is listed. Only used when disableRemoteSettings is `true`.
-   * @param {boolean} args.disableRemoteSettings do not use the official RemoteSettings server.
+   * @param {Boolean} args.disableRemoteSettings do not use the official RemoteSettings server.
    *             Default is `true`.
    * @param {String} args.website the URL of the platform website.
    */
-  constructor(args = {}) {
-    this._userArguments = { ...DEFAULT_ARGS, ...args };
+  constructor(args) {
+    this._userArguments = args;
 
     this._storage = new Storage();
     this._dataCollection = new DataCollection();

--- a/core-addon/background.js
+++ b/core-addon/background.js
@@ -8,6 +8,6 @@ const Core = require("./Core.js");
 const core = new Core({
     availableStudiesURI: __STUDIES_LIST__,
     disableRemoteSettings: __DISABLE_REMOTE_SETTINGS__,
-    website: __ION_WEBSITE_URL__,
+    website: __WEBSITE_URL__,
 });
 core.initialize();

--- a/core-addon/background.js
+++ b/core-addon/background.js
@@ -6,7 +6,7 @@ window.browser = require("webextension-polyfill");
 const Core = require("./Core.js");
 
 const core = new Core({
-    availableStudiesURI: __ION_STUDIES_LIST__,
+    availableStudiesURI: __STUDIES_LIST__,
     disableRemoteSettings: __DISABLE_REMOTE_SETTINGS__,
     website: __ION_WEBSITE_URL__,
 });

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "scripts": {
     "build": "rollup -c && npm run build-addon && web-ext build --overwrite-dest && mv web-ext-artifacts/*.zip web-ext-artifacts/rally_core.xpi",
     "build-addon": "rollup -c rollup.config.addon.js",
-    "build-local-addon": "rollup -c rollup.config.addon.js --config-disable-remote-settings --config-study-list-url=/public/locally-available-studies.json",
+    "build-local-addon": "rollup -c rollup.config.addon.js --config-disable-remote-settings --config-studies-list-url=/public/locally-available-studies.json",
     "build-storybook": "build-storybook -s ./",
     "lint": "npm run build && npm-run-all lint-*",
     "lint-addon": "web-ext lint",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "start": "sirv public",
     "storybook": "start-storybook -p 6006 -s ./",
     "test": "npm run --silent skip-taskcluster || (npm run test-addon && npm run test-support-library)",
-    "test-addon": "npm run --silent skip-taskcluster || (mocha --require  \"./tests/hooks.js\" \"./tests/core-addon/unit/*.js\")",
+    "test-addon": "npm run --silent skip-taskcluster || (mocha --unhandled-rejections=strict --require  \"./tests/hooks.js\" \"./tests/core-addon/unit/*.js\")",
     "test-integration": "npm run --silent skip-taskcluster || (npm run build && mocha --unhandled-rejections=strict --timeout 30000 \"./tests/core-addon/integration/*.js\")",
-    "test-support-library": "npm run --silent skip-taskcluster || (mocha --require  \"./tests/hooks.js\" \"./tests/support/*.mjs\")"
+    "test-support-library": "npm run --silent skip-taskcluster || (mocha --unhandled-rejections=strict --require  \"./tests/hooks.js\" \"./tests/support/*.mjs\")"
   },
   "devDependencies": {
     "@babel/core": "^7.12.3",

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -25,7 +25,7 @@ export default (cliArgs) => {
         // to enable it for testing until https://github.com/mozilla-rally/core-addon/issues/304
         // is fixed.
         __ENABLE_DATA_SUBMISSION__: !!cliArgs["config-enable-data-submission"],
-        __ION_WEBSITE_URL__: cliArgs['config-website'] ?
+        __WEBSITE_URL__: cliArgs['config-website'] ?
           `'${cliArgs['config-website']}'` :
           "'https://rally-stage.bespoke.nonprod.dataops.mozgcp.net'",
       }),

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -19,6 +19,10 @@ export default (cliArgs) => {
           `'${cliArgs['config-study-list-url']}'` :
           "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'",
         __DISABLE_REMOTE_SETTINGS__: !!cliArgs["config-disable-remote-settings"],
+        // Data submission is disabled by default. Use this option via the CLI
+        // to enable it for testing until https://github.com/mozilla-rally/core-addon/issues/304
+        // is fixed.
+        __ENABLE_DATA_SUBMISSION__: !!cliArgs["config-enable-data-submission"],
         __ION_WEBSITE_URL__: cliArgs['config-website'] ?
           `'${cliArgs['config-website']}'` :
           "'https://rally-stage.bespoke.nonprod.dataops.mozgcp.net'",

--- a/rollup.config.addon.js
+++ b/rollup.config.addon.js
@@ -15,9 +15,11 @@ export default (cliArgs) => {
     },
     plugins: [
       replace({
-        __ION_STUDIES_LIST__: cliArgs['config-study-list-url'] ?
-          `'${cliArgs['config-study-list-url']}'` :
-          "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/pioneer-study-addons-v1/records'",
+        // NOTE: if this URL ever changes, you will have to update the domain in
+        // the permissions in manifest.json.
+        __STUDIES_LIST__: cliArgs['config-studies-list-url'] ?
+          `'${cliArgs['config-studies-list-url']}'` :
+          "'https://firefox.settings.services.mozilla.com/v1/buckets/main/collections/rally-studies-v1/records'",
         __DISABLE_REMOTE_SETTINGS__: !!cliArgs["config-disable-remote-settings"],
         // Data submission is disabled by default. Use this option via the CLI
         // to enable it for testing until https://github.com/mozilla-rally/core-addon/issues/304

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -53,10 +53,6 @@ export default (cliArgs) => [{
       // Support enabling/disabling the locale check to enable
       // the development workflows on other locales.
       __DISABLE_LOCALE_CHECK__: !!cliArgs["config-disable-locale-check"],
-      // Data submission is disabled by default. Use this option via the CLI
-      // to enable it for testing until https://github.com/mozilla-rally/core-addon/issues/304
-      // is fixed.
-      __ENABLE_DATA_SUBMISSION__: !!cliArgs["config-enable-data-submission"],
     }),
     copy({
       targets: [

--- a/tests/core-addon/integration/core_addon.js
+++ b/tests/core-addon/integration/core_addon.js
@@ -222,6 +222,7 @@ describe("Core-Addon", function () {
 
     // Ensure that the study card for the base study is displayed.
     const anotherStudySelector = By.xpath(`//span[text()="Another Rally Study"]`);
+    await this.driver.wait(until.elementLocated(anotherStudySelector), WAIT_FOR_PROPERTY);
     await this.driver.findElement(anotherStudySelector);
 
     // Check that studies are installable.

--- a/tests/core-addon/unit/Core.test.js
+++ b/tests/core-addon/unit/Core.test.js
@@ -19,6 +19,7 @@ const FAKE_STUDY_LIST = [
     "addon_id": FAKE_STUDY_ID_NOT_INSTALLED
   }
 ];
+const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
 const FAKE_WEBSITE = "https://test.website";
 
 describe('Core', function () {
@@ -47,15 +48,15 @@ describe('Core', function () {
 
     // Create a mock for the privileged API.
     chrome.firefoxPrivilegedApi = {
+      generateUUID: async function() { return FAKE_UUID; },
       submitEncryptedPing: async function(type, payload, options) {},
       getRemoteSettings: async () => FAKE_STUDY_LIST,
       onRemoteSettingsSync: {
         addListener: async (callback) => {
-          callback(new Event());
+          callback(FAKE_STUDY_LIST);
         }
       },
     };
-
 
     this.core = new Core({
       website: FAKE_WEBSITE
@@ -157,20 +158,13 @@ describe('Core', function () {
       const TEST_OPTIONS_URL = "install.sample.html";
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
 
-      // Create a mock for the privileged API.
-      const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
-      chrome.firefoxPrivilegedApi = {
-        generateUUID: async function() { return FAKE_UUID; },
-        submitEncryptedPing: async function(type, payload, options) {},
-      };
-
       // Return an empty object from the local storage. Note that this
       // needs to use `browser` and must use `callsArgWith` to guarantee
       // that the promise resolves, due to a bug in sinon-chrome. See
       // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
       browser.storage.local.get.callsArgWith(1, {}).resolves();
       // Make sure to mock the local storage calls as well.
-      chrome.storage.local.set.yields();
+      browser.storage.local.set.yields();
 
       sinon.spy(this.core._dataCollection, "sendEnrollmentPing");
       sinon.spy(this.core._storage, "setRallyID");
@@ -189,11 +183,6 @@ describe('Core', function () {
       // Mock the URL of the options page.
       const TEST_OPTIONS_URL = "install.sample.html";
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
-
-      // Create a mock for the telemetry API.
-      chrome.firefoxPrivilegedApi = {
-        submitEncryptedPing: async function(type, payload, options) {},
-      };
 
       sinon.spy(this.core._dataCollection, "sendEnrollmentPing");
 
@@ -217,11 +206,6 @@ describe('Core', function () {
       // Mock the URL of the options page.
       const TEST_OPTIONS_URL = "install.sample.html";
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
-
-      // Create a mock for the telemetry API.
-      chrome.firefoxPrivilegedApi = {
-        submitEncryptedPing: async function(type, payload, options) {},
-      };
 
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       this.core._storage = {
@@ -268,11 +252,6 @@ describe('Core', function () {
       // Mock the URL of the options page.
       const TEST_OPTIONS_URL = "install.sample.html";
       chrome.runtime.getURL.returns(TEST_OPTIONS_URL);
-
-      // Create a mock for the telemetry API.
-      chrome.firefoxPrivilegedApi = {
-        submitEncryptedPing: async function(type, payload, options) {},
-      };
 
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       this.core._storage = {
@@ -334,11 +313,6 @@ describe('Core', function () {
     });
 
     it('dispatches telemetry-ping messages', async function () {
-      // Create a mock for the telemetry API.
-      chrome.firefoxPrivilegedApi = {
-        submitEncryptedPing: async function(type, payload, options) {},
-      };
-
       const FAKE_UUID = "c0ffeec0-ffee-c0ff-eec0-ffeec0ffeec0";
       this.core._storage = {
         getRallyID: async function() { return FAKE_UUID; },

--- a/tests/core-addon/unit/Storage.test.js
+++ b/tests/core-addon/unit/Storage.test.js
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
- const assert = require('assert').strict;
+const assert = require('assert').strict;
 
 var Storage = require('../../../core-addon/Storage');
 
@@ -29,6 +29,7 @@ describe('Storage', function () {
       // that the promise resolves, due to a bug in sinon-chrome. See
       // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
       browser.storage.local.get.callsArgWith(1, {}).resolves();
+      browser.storage.local.set.yields();
 
       let storedIds = await this.storage.appendActivatedStudy(TEST_ADDON_ID);
 
@@ -43,6 +44,7 @@ describe('Storage', function () {
       // that the promise resolves, due to a bug in sinon-chrome. See
       // acvetkov/sinon-chrome#101 and acvetkov/sinon-chrome#106.
       browser.storage.local.get.callsArgWith(1, {}).throws();
+      browser.storage.local.set.yields();
 
       let storedIds = await this.storage.appendActivatedStudy(TEST_ADDON_ID);
 
@@ -59,6 +61,7 @@ describe('Storage', function () {
       browser.storage.local.get
         .callsArgWith(1, {activatedStudies: [TEST_ADDON_ID]})
         .resolves();
+      browser.storage.local.set.yields();
 
       let storedIds = await this.storage.appendActivatedStudy(TEST_ADDON_ID);
 


### PR DESCRIPTION
This PR makes the tests a bit stricter and fixes them. We had exceptions in tests, but Mocha was not being too strict.

This additionally:
- drops the ION prefix from some constants;
- consolidates the default configuration options (we had conflicting values because we had them in two places)
- fix enabling the data submission (it was in the wrong config file)

Also fixes #317 

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
