### PR TITLE
Update the sign-up URL

### DIFF
--- a/support/CHANGELOG.md
+++ b/support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased changes
 
+* [#402](https://github.com/mozilla-rally/rally-core-addon/pull/402): point to the correct URL when no core add-on is found.
+
 # v0.3.0 (2021-02-08)
 
 * [#337](https://github.com/mozilla-rally/rally-core-addon/pull/337): `initialize` rejects if the study is not allowed to start.

--- a/support/rally.js
+++ b/support/rally.js
@@ -3,7 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 const CORE_ADDON_ID = "rally-core@mozilla.org";
-const SIGNUP_URL = "https://mozilla-rally.github.io/core-addon/";
+const SIGNUP_URL = "https://rally.mozilla.org/rally-required";
 
 export default class Rally {
   /**


### PR DESCRIPTION
This contributes to mozilla-rally/site#86

Instead of using the staging URL here, we're using the definitive URL directly.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
