### PR TITLE
Open the Rally control panel from the Rally website

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Unreleased changes
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v0.9.0...master)
-* [#398](https://github.com/mozilla-rally/rally-core-addon/pull/398): Use shorter name for core add-on, for UI display purposes.
 
+* [#398](https://github.com/mozilla-rally/rally-core-addon/pull/398): Use shorter name for core add-on, for UI display purposes.
 * [#392](https://github.com/mozilla-rally/rally-core-addon/pull/392): Implement the new consent logic to prevent running side-loaded studies.
+* [#403](https://github.com/mozilla-rally/rally-core-addon/pull/403): Support opening the Rally control panel from the Rally website through the `open-rally` custom event.
 
 # v0.9.0 (2021-02-09)
 

--- a/core-addon/Core.js
+++ b/core-addon/Core.js
@@ -325,17 +325,26 @@ module.exports = class Core {
     // Do not ever add other features or messages here without thinking
     // thoroughly of the implications: can the message be used to leak
     // information out? Can it be used to mess with studies?
-    //
-    // The `web-check` message should be safe: any installed addon with
-    // the `management` privileges could check for the presence of the
-    // core addon and expose that to the web. By exposing this ourselves
-    // through content scripts enabled on our domain, we don't make things
-    // worse.
-    if (message.type && message.type === "web-check") {
-      return Promise.resolve({
-        type: "web-check-response",
-        data: {}
-      });
+
+    switch (message.type) {
+      case "web-check":
+        // The `web-check` message should be safe: any installed addon with
+        // the `management` privileges could check for the presence of the
+        // core addon and expose that to the web. By exposing this ourselves
+        // through content scripts enabled on our domain, we don't make things
+        // worse.
+        return Promise.resolve({
+          type: "web-check-response",
+          data: {}
+        });
+      case "open-rally":
+        // The `open-rally` message should be safe: it exclusively opens
+        // the addon options page. It's a one-direction communication from the
+        // page, as no data gets exfiltrated or no message is reported back.
+        return Promise.resolve(this._openControlPanel());
+      default:
+        return Promise.reject(
+          new Error(`Core._handleWebMessage - unexpected message type "${message.type}"`));
     }
   }
 

--- a/core-addon/content-script.js
+++ b/core-addon/content-script.js
@@ -33,7 +33,7 @@ function sendAddonAliveEvent() {
  */
 async function sendToCore(type, data) {
   // TODO: can we automatically get the addon id for the right platform
-  // at build time?
+  // at build time? See https://github.com/mozilla-rally/rally-core-addon/issues/409
   await browser.runtime.sendMessage(
     "rally-core@mozilla.org",
     {type: type, data: data},

--- a/core-addon/content-script.js
+++ b/core-addon/content-script.js
@@ -23,6 +23,25 @@ function sendAddonAliveEvent() {
 }
 
 /**
+ * Convenience function to send a message to the Core Add-on.
+ *
+ * @param {String} type
+ *        The message type/name.
+ * @param {Object} data
+ *        An object containing the data for the message.
+ * @returns {Promise} resolved when the message is sent.
+ */
+async function sendToCore(type, data) {
+  // TODO: can we automatically get the addon id for the right platform
+  // at build time?
+  await browser.runtime.sendMessage(
+    "rally-core@mozilla.org",
+    {type: type, data: data},
+    {}
+  )
+}
+
+/**
  * Bridge page events to the background script.
  *
  * ** IMPORTANT **
@@ -30,24 +49,30 @@ function sendAddonAliveEvent() {
  * All the messages passing through here must NOT BE TRUSTED, as
  * any actor could inject custom scripts and impersonate the web page.
  */
-window.addEventListener("web-check", event => {
-  console.debug("Rally - 'web-check' message received from the page");
-  // TODO: can we automatically get the addon id for the right platform
-  // at build time?
-  browser
-    .runtime
-    .sendMessage(
-        "rally-core@mozilla.org",
-        {type: "web-check", data: {}},
-        {}
-      )
-      .then(
+function handlePageEvents(event) {
+  console.debug(`Rally - "${event.type}" message received from the page`);
+
+  switch (event.type) {
+    case "web-check": {
+      sendToCore("web-check").then(
         resolved => sendAddonAliveEvent(),
         // Even if the message was rejected, this script from the addon
         // was still injected, so the addon must be there!
         rejected => sendAddonAliveEvent()
       );
-});
+    } break;
+    case "open-rally": {
+      sendToCore("open-rally").catch(e => {
+        console.error(`Rally - unable to open the Core Add-on page`, e);
+      });
+    } break;
+    default:
+      console.error(`Rally - unknown message ${event.type} received`);
+  }
+}
+
+window.addEventListener("web-check", e => handlePageEvents(e));
+window.addEventListener("open-rally", e => handlePageEvents(e));
 
 console.debug("Rally - Running content script");
 // Send an event as soon as injected, to notify the web page if

--- a/tests/core-addon/unit/Core.test.js
+++ b/tests/core-addon/unit/Core.test.js
@@ -409,6 +409,14 @@ describe('Core', function () {
         { message: "Core - received message from an unexpected webextension unknown-test-id"}
       );
     });
+
+    it('rejects unknown messages', function () {
+      browser.runtime.id = "testid";
+      assert.rejects(
+        this.core._handleWebMessage({type: "well, not known"}, {url: FAKE_WEBSITE, id: "testid"}),
+        { message: `Core._handleWebMessage - unexpected message type "well, not known"`}
+      );
+    });
   });
 
   describe('_enrollStudy()', function () {


### PR DESCRIPTION
Fixes #140 

This enables the website to send the `open-rally` custom event that triggers the control panel to open.

The website will have to run the following JavaScript code:

```js
window.dispatchEvent(new CustomEvent("open-rally", { detail: {} }))
```

from the CTA button.

Checklist for reviewer:

- [x] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
