### PR TITLE
Send the deletion id in the enrollment ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * [#457](https://github.com/mozilla-rally/rally-core-addon/pull/457): Integrate color palette for study categories.
 * [#400](https://github.com/mozilla-rally/rally-core-addon/pull/400):  Changes the "Manage Profile" flow to redirect back to the "Current Studies" page after update.
+* [#486](https://github.com/mozilla-rally/rally-core-addon/pull/486): Properly report the `deletionId` in the enrollment ping.
 
 # v1.0.0 (2021-03-09)
 

--- a/core-addon/Core.js
+++ b/core-addon/Core.js
@@ -395,7 +395,7 @@ module.exports = class Core {
 
     // Store IDs locally for future use.
     await this._storage.setRallyID(rallyId);
-    await this._storage.setDeletionID(rallyId);
+    await this._storage.setDeletionID(deletionId);
 
     // Override the uninstall URL to include the rallyID, for deleting data without exposing the Rally ID.
     await this.setUninstallURL();

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -92,6 +92,12 @@ module.exports = class DataCollection {
       return await this._sendPingWithDeletionId(rallyId, "pioneer-enrollment", studyAddonId);
     }
 
+    // If this is a platform enrollment ping (not coming from the study), then the
+    // `deletionId` should always be sent.
+    if (deletionId === undefined) {
+      throw new Error("DataCollection - the enrollment ping must have a deletion id");
+    }
+
     // Note that the schema namespace directly informs how data is segregated after ingestion.
     // If this is an enrollment ping for the pioneer program (in contrast to the enrollment to
     // a specific study), use a meta namespace.

--- a/tests/core-addon/unit/DataCollection.test.js
+++ b/tests/core-addon/unit/DataCollection.test.js
@@ -28,7 +28,7 @@ describe('DataCollection', function () {
         sinon.spy(chrome.firefoxPrivilegedApi, "submitEncryptedPing");
 
       // Provide a valid enrollment message.
-      await this.dataCollection.sendEnrollmentPing("some-rally-id");
+      await this.dataCollection.sendEnrollmentPing("some-rally-id", undefined, "deletion-id");
 
       // We expect to submit a ping with the expected type ...
       const submitArgs = telemetrySpy.getCall(0).args;
@@ -36,6 +36,7 @@ describe('DataCollection', function () {
       // ... a payload containing only the deletion ID ...
       assert.equal(Object.keys(submitArgs[1]).length, 1);
       assert.ok(Object.keys(submitArgs[1]).includes("deletionId"));
+      assert.equal(submitArgs[1]["deletionId"], "deletion-id");
       // ... and a specific set of options.
       assert.equal(submitArgs[2].overridePioneerId, "some-rally-id");
       assert.equal(submitArgs[2].studyName, "pioneer-core");


### PR DESCRIPTION
This make sure we're sending both the deletion id and the rally id in the enrollment ping, not two copies of the rally id.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
