### PR TITLE
Look for the new label for confirming add-on installation

### DIFF
--- a/tests/core-addon/integration/core_addon.js
+++ b/tests/core-addon/integration/core_addon.js
@@ -28,7 +28,7 @@ describe("Core-Addon", function () {
     // Switch to browser UI context, to interact with Firefox add-on install prompts.
     await this.driver.setContext(firefox.Context.CHROME);
     await utils.findAndAct(this.driver, By.css(`[label="Add"]`), e => e.click());
-    await utils.findAndAct(this.driver, By.css(`[label="Okay, Got It"]`), e => e.click());
+    await utils.findAndAct(this.driver, By.css(`[label="Okay"]`), e => e.click());
 
     // Close options page tab and re-open it.
     await this.driver.close();
@@ -129,7 +129,7 @@ describe("Core-Addon", function () {
     // Switch to browser UI context, to interact with Firefox add-on install prompts.
     await this.driver.setContext(firefox.Context.CHROME);
     await utils.findAndAct(this.driver, By.css(`[label="Add"]`), e => e.click());
-    await utils.findAndAct(this.driver, By.css(`[label="Okay, Got It"]`), e => e.click());
+    await utils.findAndAct(this.driver, By.css(`[label="Okay"]`), e => e.click());
 
     await this.driver.quit();
   });
@@ -179,7 +179,7 @@ describe("Core-Addon", function () {
     // Switch to browser UI context, to interact with Firefox add-on install prompts.
     await this.driver.setContext(firefox.Context.CHROME);
     await utils.findAndAct(this.driver, By.css(`[label="Add"]`), e => e.click());
-    await utils.findAndAct(this.driver, By.css(`[label="Okay, Got It"]`), e => e.click());
+    await utils.findAndAct(this.driver, By.css(`[label="Okay"]`), e => e.click());
 
     // Switch to browser UI context, so we can inject script to modify Remote Settings.
     await this.driver.setContext(firefox.Context.CHROME);

--- a/tests/core-addon/integration/utils.js
+++ b/tests/core-addon/integration/utils.js
@@ -241,7 +241,7 @@ async function installRally(driver) {
   // switch to browser UI context, to interact with Firefox add-on install prompts.
   await driver.setContext(firefox.Context.CHROME);
   await findAndAct(driver, By.css(`[label="Add"]`), e => e.click());
-  await findAndAct(driver, By.css(`[label="Okay, Got It"]`), e => e.click());
+  await findAndAct(driver, By.css(`[label="Okay"]`), e => e.click());
 
   // We expect the extension to load its options page in a new tab.
   await driver.wait(async () => {


### PR DESCRIPTION
In bug https://bugzilla.mozilla.org/show_bug.cgi?id=1697622 the
label of the confirmation button was changed, making our tests look
for the wrong element. This updates the tests to look for the newest
label. A more robust approach that looks at the id can be implemented
in future, separate PRs.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
