### PR TITLE
Final touches to enable Glean.js

### DIFF
--- a/core-addon/Core.js
+++ b/core-addon/Core.js
@@ -407,6 +407,10 @@ export default class Core {
     await this._storage.setRallyID(rallyId);
     await this._storage.setDeletionID(deletionId);
 
+    // We enrolled in the Rally platform, we're now good
+    // to start uploading data if needed.
+    Glean.setUploadEnabled(true);
+
     rallyMetrics.id.set(rallyId);
 
     // Override the uninstall URL to include the rallyID, for deleting data without exposing the Rally ID.

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -28,7 +28,7 @@ export default class DataCollection {
    *        Whether or not user has enrolled in the platform.
    */
   initialize(userEnrolled) {
-    if (!__ENABLE_GLEAN__) {
+    if (!__ENABLE_DATA_SUBMISSION__ || !__ENABLE_GLEAN__) {
       console.warn("DataCollection - Glean disabled by the build configuration.");
       return;
     }

--- a/core-addon/DataCollection.js
+++ b/core-addon/DataCollection.js
@@ -37,6 +37,7 @@ export default class DataCollection {
     // consented to join Rally. Upload is always enabled unless the web-extension
     // is uninstalled.
     Glean.initialize("rally-core", userEnrolled, {
+        appDisplayVersion: browser.runtime.getManifest().version,
         plugins: [
           new PingEncryptionPlugin(CORE_ENCRYPTION_JWK)
         ]

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,8 @@
     "management",
     "telemetry",
     "storage",
-    "https://firefox.settings.services.mozilla.com/"
+    "https://firefox.settings.services.mozilla.com/",
+    "https://incoming.telemetry.mozilla.org/"
   ],
 
   "telemetry": {

--- a/tests/core-addon/unit/Core.test.js
+++ b/tests/core-addon/unit/Core.test.js
@@ -53,6 +53,7 @@ describe('Core', function () {
       .callsArgWith(1, {activatedStudies: [FAKE_STUDY_ID]})
       .resolves();
     chrome.runtime.sendMessage.yields();
+    chrome.runtime.getManifest.returns({version: "1.2.3"});
 
     // NodeJS doesn't support "fetch" so we need to mock it
     // manually (or use a third party package). This isn't too


### PR DESCRIPTION
With the changes below, by providing the proper encryption key (the one currently being used for the legacy telemetry cannot be used for Glean.js, as we want to keep the environment separate), data collection with Glean.js in the core add-on is ready for prime time.

This contributes to #545 .

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
