### PR TITLE
Change collaborators to collaborates

### DIFF
--- a/src/routes/terms-of-service/Content.svelte
+++ b/src/routes/terms-of-service/Content.svelte
@@ -211,7 +211,7 @@
       <h4>Our Research Collaborators</h4>
 
       <div>
-        Rally collaborators with trusted third parties to build and release studies. 
+        Rally collaborates with trusted third parties to build and release studies. 
         For any studies you join, we may ask you to share the data collected
         under <b>this Privacy Notice</b> with third party researcher(s)
         administering the study. Our research collaborators are under contracts


### PR DESCRIPTION
In #546 this instance of the word `partners` was mistaken for the noun `partners` when it's actually the verb. Consequently, this should have been changed to `collaborates` not `collaborators`

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
