### PR TITLE
Turn Glean data collection on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v1.2.1...master)
 
+* [#601](https://github.com/mozilla-rally/rally-core-addon/pull/601): Enable submitting data with Glean in addition to the legacy collection.
+
 # v1.2.1 (2021-04-27)
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v1.2.0...v1.2.1)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "prebuild": "node scripts/setupTaskcluster.js",
     "build": "rollup -c && npm run build-addon && web-ext --config=web-ext-config.cjs build --overwrite-dest && mv web-ext-artifacts/*.zip web-ext-artifacts/rally_core.xpi",
-    "build-addon": "npm run glean && rollup -c rollup.config.addon.js --config-enable-data-submission",
+    "build-addon": "npm run glean && rollup -c rollup.config.addon.js --config-enable-data-submission --config-enable-glean",
     "build-local-addon": "npm run glean && rollup -c rollup.config.addon.js --config-disable-remote-settings --config-studies-list-url=/public/locally-available-studies.json",
     "build-storybook": "build-storybook -s ./public",
     "glean": "npm run glean-metrics && npm run glean-docs",


### PR DESCRIPTION
This makes sure Glean is turned on when packing the final add-on.

Let's not merge this until we give it a final QA pass :-)

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
