### PR TITLE
add the Stanford Beyond the Paywall IRB component; add story component

### DIFF
--- a/src/components/study-card/study-categories.js
+++ b/src/components/study-card/study-categories.js
@@ -33,5 +33,13 @@ export default {
     "product discovery": {
         text: "var(--color-marketing-gray-100)",
         background: "#FFB4DC"
+    },
+    "news": {
+        text: "var(--color-marketing-gray-100)",
+        background: "#facfcb"
+    },
+    "advertising": {
+        text: "var(--color-marketing-gray-100)",
+        background: "#D1FFEE"
     }
 }

--- a/src/routes/irbs/StanfordBeyondThePaywallIRB.svelte
+++ b/src/routes/irbs/StanfordBeyondThePaywallIRB.svelte
@@ -55,7 +55,7 @@ dd {
     <div>You are invited to participate in a <b>research study</b>.</div>
 </div>
 
-<dl>
+<!-- <dl>
     <dt>Academic Institution</dt>
     <dd>Stanford GSB</dd>
     <dt>Study Name</dt>
@@ -64,12 +64,7 @@ dd {
     <dd>
         Gregory John Martin
     </dd>
-    </dl>
-
-<h2>IRB Approval</h2>
-<p>
-    This study has been approved by the Institutional Review Board for Human Subjects at Princeton University.
-</p>
+    </dl> -->
 
 <h2>Research Question</h2>
 <p>

--- a/src/routes/irbs/StanfordBeyondThePaywallIRB.svelte
+++ b/src/routes/irbs/StanfordBeyondThePaywallIRB.svelte
@@ -1,0 +1,193 @@
+<style>
+/* This Source Code Form is subject to the terms of the Mozilla Public
+    * License, v. 2.0. If a copy of the MPL was not distributed with this
+    * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+
+.research-is-voluntary, h1, h2, p, dl {
+    color: var(--irb-text-color, var(--color-marketing-gray-70));
+}
+
+.research-is-voluntary {
+    font-size: 16px;
+    margin-bottom: 28px;
+}
+
+h1 {
+    font-size: 24px;
+    font-family: "Zilla Slab", -apple-system, BlinkMacSystemFont, "Segoe UI",
+        Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+        "Segoe UI Symbol";
+    margin-bottom: 28px;
+}
+h2 {
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 24px;
+    font-family: "Inter", -apple-system, BlinkMacSystemFont, "Segoe UI",
+        Roboto, Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji",
+        "Segoe UI Symbol";
+}
+
+p {
+    font-size: 14px;
+    line-height: 21px;
+    margin-bottom: 20px;
+}
+
+dl {
+    margin-bottom: 32px;
+}
+
+dt {
+    font-weight: 900;
+    text-transform: uppercase;
+}
+
+dd {
+    margin-bottom: 1rem;
+}
+
+</style>
+
+<h1>Rally Study Privacy Consent Notice</h1>
+
+<div class='research-is-voluntary'>
+    <div>You are invited to participate in a <b>research study</b>.</div>
+</div>
+
+<dl>
+    <dt>Academic Institution</dt>
+    <dd>Stanford Graduate School of Business</dd>
+    <dt>Study Name</dt>
+    <dd>Online News Consumption</dd>
+    <dt>Principal Investigator</dt>
+    <dd>
+        Gregory John Martin
+    </dd>
+    </dl>
+
+<h2>IRB Approval</h2>
+<p>
+    This study has been approved by the Institutional Review Board for Human Subjects at Princeton University.
+</p>
+
+<h2>Research Question</h2>
+<p>
+    Local newspapers are an essential link in the chain of democratic accountability, but
+    changes in the economics of news production and consumption threaten their survival.
+    This project aims to measure both the accountability impact of, and consumers'
+    willingness to pay for, investigative journalism by local outlets, enhancing our
+    understanding of the political consequences of changes in the economics of news media
+    as well as informing future choices about alternative funding models.
+</p>
+
+<h2>Public Interest</h2>
+<p>
+    Journalism, and especially local reporting, is a vital component of a functioning
+    democracy. However, the traditional model of funding local journalism has been failing in
+    recent years and local publications have been shutting down in startling numbers. The
+    aim of our project is to investigate the feasibility of alternative models of funding and
+    sustaining local journalism in the internet age.
+</p>
+
+<h2>Study Procedures</h2>
+<p>
+    During the study, your browser will automatically send data to Mozilla about how you engage with health and news websites, 
+    in addition to standard Firefox telemetry. We have taken a number of steps to minimize and protect this data, which we describe below. 
+    You may also be asked to participate in periodic surveys. 
+    If you choose to provide demographic information for Mozilla Rally research purposes, 
+    that information will also be used for this study.
+</p>
+
+<h2>Data Collection</h2>
+<p>
+    Data will be collected through a custom browser plug-in that is developed collaboratively
+    between the teams at Stanford and Mozilla. The plug-in will be offered on a voluntary
+    basis to a pool of browser users that have opted in to the Mozilla Rally experience. If a
+    participant opts in to the study, they will install the plug-in and data will be collected
+    through browser telemetry. Mozilla will store the data on Google Cloud where all
+    analysis will be conducted. This server is restricted to the research team and Mozilla. The
+    server is encrypted. Data will be transferred between the participant's browser and the
+    Mozilla analysis database protected by TLS.
+</p>
+
+<h2>Time Involvement</h2>
+
+<p>This research will take one year.</p>
+
+<h2>Risks and Benefits</h2>
+
+<p>
+    <b>We cannot and do not guarantee or promise that you will receive any benefits from this study</b>. 
+    There are no individual risks or benefits for participants.
+</p>
+
+<h2>Payments</h2>
+
+<p>No payment is provided.</p>
+
+<h2>Participant's Rights</h2>
+
+<p>
+    If you have read this form and have decided to participate in
+    this project, please understand your <b>participation is voluntary</b> and you have the <b>right to
+    withdraw your consent or discontinue participation at any time without penalty or loss
+    of benefits to which you are otherwise entitled. The alternative is not to participate</b>.
+    You have the right to refuse to answer particular questions. The results of this research
+    study may be presented at scientific or professional meetings or published in scientific
+    journals. Your individual privacy will be maintained in all published and written data
+    resulting from the study.
+
+</p>
+
+
+<h2>Leaving the Study</h2>
+<p>
+    You can leave the study at any time from the Mozilla Rally options page. 
+    To access the page, click on the Rally button <img style="padding: 0 4px;" width="18" src="img/rally-toolbar-icon.svg" alt="rally icon" /> in your browser toolbar. 
+    The button is usually near the top right of the browser window. 
+    If you have removed the Rally button from your toolbar, 
+    you can also access the Rally options page from the browser’s Add-ons settings. 
+    The Rally options page will show you a list of studies that you are currently enrolled in. 
+    You can leave this study by clicking the “Leave Study” button on the associated study card.  
+    If you leave the study, the study’s browser extension will be automatically uninstalled, 
+    removing the study code and data from your browser. 
+    We will also automatically delete the data that your browser has submitted for the study, 
+    unless you allow us to retain that data.
+    You may not be able to rejoin the study if you leave. 
+    If you leave Rally, you will also leave the studies that you are enrolled in, including this study.
+</p>
+
+<h2>Confidentiality</h2>
+<p>
+    Your private information collected as part of the research, even if identifiers are removed,
+    will not be used or distributed for future research studies.
+</p>
+
+<h2>Privacy</h2>
+<p>
+    We will protect the information that you provide in several ways: minimizing the data we collect, 
+    keeping the data we collect secure, and limiting the information we use and disclose.
+</p>
+
+<h2>Contact Information</h2>
+<p>
+    <em>Questions</em>: If you have any questions, concerns or complaints about this research, its
+    procedures, risks and benefits, contact the Protocol Director, Gregory Martin by phone at
+    650-498-3321 or by email at <a href="mailto:gjmartin@stanford.edu">gjmartin@stanford.edu</a>.
+</p>
+
+<p>
+    <em>Independent Contact</em>: If you are not satisfied with how this study is being conducted, or if
+    you have any concerns, complaints, or general questions about the research or your
+    rights as a participant, please contact the Stanford Institutional Review Board (IRB) to
+    speak to someone independent of the research team at (650)-723-2480 or toll free at
+    1-866-680-2906, or email at <a href="mailto:IRB2-Manager@lists.stanford.edu">IRB2-Manager@lists.stanford.edu</a>. 
+    You can also write to the
+    Stanford IRB, Stanford University, 1705 El Camino Real, Palo Alto, CA 94306.
+</p>
+
+<p><b>Please print a copy of this page for your records</b>.</p>
+
+<p>If you agree to participate in this research, please click “Accept & Participate”.</p>
+

--- a/src/routes/irbs/StanfordBeyondThePaywallIRB.svelte
+++ b/src/routes/irbs/StanfordBeyondThePaywallIRB.svelte
@@ -57,9 +57,9 @@ dd {
 
 <dl>
     <dt>Academic Institution</dt>
-    <dd>Stanford Graduate School of Business</dd>
+    <dd>Stanford GSB</dd>
     <dt>Study Name</dt>
-    <dd>Online News Consumption</dd>
+    <dd>Beyond the Paywall</dd>
     <dt>Principal Investigator</dt>
     <dd>
         Gregory John Martin

--- a/src/routes/irbs/index.js
+++ b/src/routes/irbs/index.js
@@ -3,8 +3,10 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 import PrincetonCovidDisinformationIRB from "./PrincetonCovidDisinformationIRB.svelte";
 import RS01Consent from "./RS01Consent.svelte";
+import StanfordBeyondThePaywallIRB from "./StanfordBeyondThePaywallIRB.svelte";
 
 export default {
     "rally.news.study@princeton.edu": PrincetonCovidDisinformationIRB,
-    "rally-study-01@mozilla.org": RS01Consent
+    "rally-study-01@mozilla.org": RS01Consent,
+    "beyond-the-paywall@rally.mozilla.org": StanfordBeyondThePaywallIRB
 }

--- a/stories/flow/MainFlowView.svelte
+++ b/stories/flow/MainFlowView.svelte
@@ -91,7 +91,7 @@ const additionalMockPartnerStudy = {
         64: undefined
     },
     endDate: new Date('2021-07-03'),
-    tags: ['social media', 'quantified self'],
+    tags: ['advertising', 'news'],
     privacyPolicy: {spec: 'https://example.com'},
 
     description: `This is another mock study that utilizes the 'Beyond the Paywall' IRB consent.`,

--- a/stories/flow/MainFlowView.svelte
+++ b/stories/flow/MainFlowView.svelte
@@ -81,10 +81,29 @@ const mockAcademicPartnerStudy = {
     studyDetailsLink: '/'
 }
 
+const additionalMockPartnerStudy = {
+    addonId: 'beyond-the-paywall@rally.mozilla.org',
+    name: "Another Collaborator Study",
+    authors: {
+        name: "Another Collaborator University"
+    },
+    icons: {
+        64: undefined
+    },
+    endDate: new Date('2021-07-03'),
+    tags: ['social media', 'quantified self'],
+    privacyPolicy: {spec: 'https://example.com'},
+
+    description: `This is another mock study that utilizes the 'Beyond the Paywall' IRB consent.`,
+    dataCollectionDetails: ['page views', 'time and date of joining study', 'etc.'],
+    detailsDirectName: "Rally Website",
+    studyDetailsLink: '/'
+}
+
 fetch('locally-available-studies.json')
     .then(r => r.json())
     .then(s => {
-        mockStore.set({...get(mockStore), availableStudies: [nicerStudy, mockAcademicPartnerStudy, ...s]});
+        mockStore.set({...get(mockStore), availableStudies: [nicerStudy, mockAcademicPartnerStudy, additionalMockPartnerStudy, ...s]});
 });
 
 setContext("rally:store", mockStore);

--- a/stories/irb/StanfordBeyondThePaywallIRB.svelte
+++ b/stories/irb/StanfordBeyondThePaywallIRB.svelte
@@ -1,0 +1,14 @@
+<script>
+    /* This Source Code Form is subject to the terms of the Mozilla Public
+     * License, v. 2.0. If a copy of the MPL was not distributed with this
+     * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
+    
+    import IRB from "../../src/routes/irbs/StanfordBeyondThePaywallIRB.svelte";
+    import IRBWindow from "../../src/routes/irbs/IRBWindow.svelte";
+    </script>
+    
+    <div style="--height: 700px;">
+    <IRBWindow>
+        <IRB />
+    </IRBWindow>
+    </div>

--- a/stories/irb/irb.stories.js
+++ b/stories/irb/irb.stories.js
@@ -3,6 +3,7 @@
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 
 import PrincetonIRBStory from './PrincetonIRB.svelte';
+import StanfordBeyondThePaywallIRBStory from "./StanfordBeyondThePaywallIRB.svelte"
 import RS01ConsentStory from './RS01Consent.svelte';
 export default {
   title: "IRB Components",
@@ -10,6 +11,10 @@ export default {
 
 export const PrincetonIRB = () => ({
   Component: PrincetonIRBStory,
+});
+
+export const StanfordBeyondThePaywallIRB = () => ({
+  Component: StanfordBeyondThePaywallIRBStory,
 });
 
 export const RS01Consent = () => ({


### PR DESCRIPTION
Addresses consent component in #575.

The content of the consent notice can be checked out in [this storybook deploy](https://competent-kirch-f0364f.netlify.app/?path=/story/irb-components--stanford-beyond-the-paywall-irb).

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
