### PR TITLE
Pre-format manifest.json in a way AMO is happy with.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v1.3.2...master)
 
+* [#656](https://github.com/mozilla-rally/rally-core-addon/pull/656): Pre-format manifest.json in a way AMO likes, to work around AMO bug.
 * [#653](https://github.com/mozilla-rally/rally-core-addon/pull/653): Bump rally.js version to 0.7.0
 * [#651](https://github.com/mozilla-rally/rally-core-addon/pull/651): Pass Rally ID during core-check response, for use by glean in studies.
 

--- a/manifest.json
+++ b/manifest.json
@@ -5,19 +5,16 @@
   "name": "Mozilla Rally",
   "version": "1.3.2",
   "homepage_url": "https://github.com/mozilla-rally/rally-core-addon",
-
   "icons": {
     "48": "public/img/rally-favicon.svg",
     "96": "public/img/rally-favicon.svg"
   },
-
   "applications": {
     "gecko": {
       "id": "rally-core@mozilla.org",
       "strict_min_version": "80.0a1"
     }
   },
-
   "permissions": [
     "management",
     "telemetry",
@@ -25,7 +22,6 @@
     "https://firefox.settings.services.mozilla.com/",
     "https://incoming.telemetry.mozilla.org/"
   ],
-
   "telemetry": {
     "pioneer_id": true,
     "study_name": "rally-core",
@@ -41,36 +37,43 @@
       }
     }
   },
-
   "background": {
-    "scripts": ["public/addon-build/background.js"]
+    "scripts": [
+      "public/addon-build/background.js"
+    ]
   },
-
   "content_scripts": [
     {
-      "matches": ["https://rally.mozilla.org/*"],
-      "js": ["public/addon-build/content-script.js"]
+      "matches": [
+        "https://rally.mozilla.org/*"
+      ],
+      "js": [
+        "public/addon-build/content-script.js"
+      ]
     }
   ],
-
   "browser_action": {
     "browser_style": true,
     "default_icon": "public/img/rally-toolbar-icon.svg"
   },
-
   "options_ui": {
     "page": "public/index.html",
     "open_in_tab": true
   },
-
   "experiment_apis": {
     "firefoxPrivilegedApi": {
       "schema": "core-addon/FirefoxPrivilegedApi.schema.json",
       "parent": {
-        "scopes": ["addon_parent"],
+        "scopes": [
+          "addon_parent"
+        ],
         "script": "core-addon/FirefoxPrivilegedApi.js",
         "events": [],
-        "paths": [["firefoxPrivilegedApi"]]
+        "paths": [
+          [
+            "firefoxPrivilegedApi"
+          ]
+        ]
       }
     }
   }


### PR DESCRIPTION
https://github.com/mozilla/addons-server/issues/17302 broke our privileged signature, the AMO team is working on a fix
but this is a workaround.

Checklist for reviewer:

- [ ] The description should reference a bug or github issue, if relevant.
- [ ] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [ ] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [ ] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
