### PR TITLE
Disable new tab to 'Hold up' page when core add-on not present or enr…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased changes
 
 [Full changelog](https://github.com/mozilla-rally/core-addon/compare/v1.3.5...master)
+* [#752](https://github.com/mozilla-rally/rally-core-addon/pull/752): Stop prompting for onboarding when studies are side-loaded.
 
 # v1.3.5 (2021-10-15)
 

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "glean": "npm run glean-metrics && npm run glean-docs",
     "glean-metrics": "glean translate ./metrics.yaml ./pings.yaml -f javascript -o public/generated",
     "glean-docs": "glean translate ./metrics.yaml ./pings.yaml -f markdown -o docs",
-    "lint": "npm run build && npm-run-all lint-*",
+    "lint": "npm run --silent skip-taskcluster || (npm run build && npm-run-all lint-*)",
     "lint-addon": "web-ext --config=web-ext-config.cjs lint",
     "lint-css": "stylelint 'public/*.css' '.storybook/*.css' 'src/**/*.svelte' 'stories/**/*.svelte'",
     "lint-glean": "glean glinter ./metrics.yaml ./pings.yaml",

--- a/support/CHANGELOG.md
+++ b/support/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased changes
 
+* [#752](https://github.com/mozilla-rally/rally-core-addon/pull/752): Stop prompting for onboarding when studies are side-loaded.
+
+# v0.7.0 (2021-06-13)
+
+* [#656] Pre-format manifest.json in a way AMO is happy with.
+
 # v0.6.0 (2021-04-20)
 
 * [550](https://github.com/mozilla-rally/rally-core-addon/pull/550): Do not use extension ID as namespace, breaks the `rally.js` API (constructor arg change)

--- a/support/CHANGELOG.md
+++ b/support/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased changes
 
+# v0.7.1 (2021-12-03)
+
 * [#752](https://github.com/mozilla-rally/rally-core-addon/pull/752): Stop prompting for onboarding when studies are side-loaded.
 
 # v0.7.0 (2021-06-13)

--- a/support/package-lock.json
+++ b/support/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/rally",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/support/package.json
+++ b/support/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mozilla/rally",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "The Rally partner support library.",
   "main": "rally.js",
   "type": "module",

--- a/support/rally.js
+++ b/support/rally.js
@@ -3,7 +3,6 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 const CORE_ADDON_ID = "rally-core@mozilla.org";
-const SIGNUP_URL = "https://rally.mozilla.org/rally-required";
 
 export const runStates = {
 	RUNNING: "running",
@@ -71,7 +70,6 @@ export class Rally {
 
       // The Core Add-on was not found and we're not in developer
       // mode.
-      await browser.tabs.create({ url: SIGNUP_URL });
       return false;
     });
 

--- a/tests/core-addon/integration/consent.js
+++ b/tests/core-addon/integration/consent.js
@@ -34,22 +34,11 @@ describe("side-loaded studies found before Rally installs", function () {
     let studyInstalled = await utils.isAddonInstalled(this.driver, studyInstallId);
     assert.ok(studyInstalled);
 
-    // Installing the study will open an "Install Rally" page.
-    // Once it's opened, close it.
-    await this.driver.wait(async () => {
-      return (await this.driver.getAllWindowHandles()).length === 2;
-    }, utils.WAIT_FOR_PROPERTY);
-    const openedTabs = await this.driver.getAllWindowHandles();
-    await this.driver.switchTo().window(openedTabs[1]);
-    await this.driver.close();
-    await this.driver.switchTo().window(openedTabs[0]);
-
     await utils.installRally(this.driver);
     await utils.joinRally(this.driver);
-
     await this.driver.wait(until.elementLocated(By.css("button")));
     await utils.findAndAct(this.driver, By.xpath(`//button[text()="Join Study"]`), e => e.click());
-  
+
     // The following operation will reject because we cannot install
     // an add-on, through a link, from the disk. It's fine, we don't
     // care about this problem in this test, so just catch the network
@@ -57,9 +46,9 @@ describe("side-loaded studies found before Rally installs", function () {
     assert.rejects(
       utils.findAndAct(this.driver, By.xpath(`(//button[text()="Join Study"])[2]`), e => e.click())
     );
-    
+
     await this.driver.uninstallAddon(studyInstallId);
-    
+
     // Clicking "Join" must have triggered the uninstallation of
     // the existing study.
     studyInstalled = await utils.isAddonInstalled(this.driver, studyInstallId);
@@ -96,22 +85,10 @@ describe("side-loaded studies found before Rally installs", function () {
     let studyInstalled = await utils.isAddonInstalled(this.driver, studyInstallId);
     assert.ok(studyInstalled);
 
-    // Installing the study will open an "Install Rally" page.
-    // Even though the Rally Core Add-on is installed, the study
-    // is not joined.
-    // Once it's opened, close it.
-    await this.driver.wait(async () => {
-      return (await this.driver.getAllWindowHandles()).length === 3;
-    }, utils.WAIT_FOR_PROPERTY);
-    const openedTabs = await this.driver.getAllWindowHandles();
-    await this.driver.switchTo().window(openedTabs[2]);
-    await this.driver.close();
-    await this.driver.switchTo().window(openedTabs[1]);
-
     // Make sure to find the "join" button on the study page.
     await this.driver.wait(until.elementLocated(By.css("button")));
     await utils.findAndAct(this.driver, By.xpath(`//button[text()="Join Study"]`), e => e.click());
-   
+
     await this.driver.quit();
   });
 });

--- a/tests/support/rally.test.mjs
+++ b/tests/support/rally.test.mjs
@@ -68,8 +68,6 @@ describe('Rally', function () {
           () => {},
         )
       );
-
-      assert.ok(chrome.tabs.create.calledOnce);
     });
 
     it('must export the list of valid run states', function () {


### PR DESCRIPTION
…olled

Checklist for reviewer:

- [x] The description should reference a bug or github issue, if relevant.
- [x] There must be a [`CHANGELOG.md`](./CHANGELOG.md) entry for any non-test change.
- [x] Any change to the NPM commands must be carefully reviewed to make sure it won't break the Add-ons pipeline.
- [x] Any version increase must follow the [release process](./docs/RELEASE_PROCESS.md).
